### PR TITLE
enlarge font size in #padcontent

### DIFF
--- a/etherpad/src/static/css/broadcast.css
+++ b/etherpad/src/static/css/broadcast.css
@@ -4,6 +4,7 @@
 
 #padcontent {
   padding: 10px;
+  font-size: 128%;
 }
 
 #timeslider-wrapper {


### PR DESCRIPTION
the font size inherited from &lt;html&gt; - 62.5% on readonly version is way too small for chinese language.

also why ordered/unordered list tags are all ignored? read-only page looks bad when list tags are often used for alignment. for instance:
https://etherpad.mozilla.org/pLBDBIV0am
https://etherpad.mozilla.org/ep/pad/view/ro.sL6GKEe68Yw/latest
