### PR TITLE
disable and hide PDF/ODT/DOC import/export [#1034677]

### DIFF
--- a/etherpad/src/etherpad/importexport/importexport.js
+++ b/etherpad/src/etherpad/importexport/importexport.js
@@ -42,10 +42,7 @@ function onStartup() {
 }
 
 var formats = {
-  pdf: 'application/pdf',
-  doc: 'application/msword',
   html: 'text/html; charset=utf-8',
-  odt: 'application/vnd.oasis.opendocument.text',
   txt: 'text/plain; charset=utf-8'
 }
 

--- a/etherpad/src/themes/default/templates/pad/pad_body2.ejs
+++ b/etherpad/src/themes/default/templates/pad/pad_body2.ejs
@@ -157,9 +157,6 @@ limitations under the License. */ %>
 	      <%= exportLink('html', 1, 'HTML', false) %>
 	      <%= exportLink('txt', 2, 'Plain text', false) %>
 	      <%= exportLink('link', 3, 'Bookmark file', false, '/ep/pad/linkfile?padId='+localPadId, 'This will save a file that, when opened, takes you to this pad.') %>
-	      <%= exportLink('doc', 4, 'Microsoft Word', true) %>
-	      <%= exportLink('pdf', 5, 'PDF', true) %>
-	      <%= exportLink('odt', 6, 'OpenDocument', true) %>
 	    </div>
 	    <%: template.callHookStr('padExportForm', {}, '', '<div>', '</div>'); %>
 	  </div><!-- /impexp-export -->

--- a/etherpad/src/themes/default/templates/pad/pad_content.ejs
+++ b/etherpad/src/themes/default/templates/pad/pad_content.ejs
@@ -193,17 +193,17 @@ limitations under the License. */ %><%
       <table>
 				<tr>
 					<td class="firsttd"><%= exportOption('html', 'HTML', false) %></td>
-      		<td class="secondtd"><%= exportOption('doc', 'Microsoft Word', true) %></td>
+      		<td class="secondtd">&nbsp;</td>
 				</tr>
 				<tr>
 					<td class="firsttd"><%= exportOption('txt', 'Plain text', false) %></td>
-      		<td class="secondtd"><%= exportOption('pdf', 'PDF', true) %></td>
+      		<td class="secondtd">&nbsp;</td>
 				</tr>
 				<tr>
 					<td class="firsttd"><%= exportOption('link', 'Bookmark file', false,
 																							 '/ep/pad/linkfile?padId='+padId,
 						'This will save a file that, when opened, takes you to this pad.') %></td>
-					<td class="secondtd"><%= exportOption('odt', 'OpenDocument', true) %></td>
+					<td class="secondtd">&nbsp;</td>
 				</tr>
 			</table>
 			<div id="exportmessage"></div>

--- a/etherpad/src/themes/micro/default/templates/pad/pad_body2.ejs
+++ b/etherpad/src/themes/micro/default/templates/pad/pad_body2.ejs
@@ -156,9 +156,6 @@ limitations under the License. */ %>
 	      <%= exportLink('html', 1, 'HTML', false) %>
 	      <%= exportLink('txt', 2, 'Plain text', false) %>
 	      <%= exportLink('link', 3, 'Bookmark file', false, '/ep/pad/linkfile?padId='+localPadId, 'This will save a file that, when opened, takes you to this pad.') %>
-	      <%= exportLink('doc', 4, 'Microsoft Word', true) %>
-	      <%= exportLink('pdf', 5, 'PDF', true) %>
-	      <%= exportLink('odt', 6, 'OpenDocument', true) %>
 	    </div>
 	  </div><!-- /impexp-export -->
 	  <div id="impexp-divider"><!-- --></div>

--- a/etherpad/src/themes/micro/default/templates/pad/pad_content.ejs
+++ b/etherpad/src/themes/micro/default/templates/pad/pad_content.ejs
@@ -193,17 +193,17 @@ limitations under the License. */ %><%
       <table>
 				<tr>
 					<td class="firsttd"><%= exportOption('html', 'HTML', false) %></td>
-      		<td class="secondtd"><%= exportOption('doc', 'Microsoft Word', true) %></td>
+      		<td class="secondtd">&nbsp;</td>
 				</tr>
 				<tr>
 					<td class="firsttd"><%= exportOption('txt', 'Plain text', false) %></td>
-      		<td class="secondtd"><%= exportOption('pdf', 'PDF', true) %></td>
+      		<td class="secondtd">&nbsp;</td>
 				</tr>
 				<tr>
 					<td class="firsttd"><%= exportOption('link', 'Bookmark file', false,
 																							 '/ep/pad/linkfile?padId='+padId,
 						'This will save a file that, when opened, takes you to this pad.') %></td>
-					<td class="secondtd"><%= exportOption('odt', 'OpenDocument', true) %></td>
+					<td class="secondtd">&nbsp;</td>
 				</tr>
 			</table>
 			<div id="exportmessage"></div>

--- a/etherpad/src/themes/micro/templates/pad/pad_body2.ejs
+++ b/etherpad/src/themes/micro/templates/pad/pad_body2.ejs
@@ -170,9 +170,6 @@ limitations under the License. */ %>
 	      <%= exportLink('html', 1, 'HTML', false) %>
 	      <%= exportLink('txt', 2, 'Plain text', false) %>
 	      <%= exportLink('link', 3, 'Bookmark file', false, '/ep/pad/linkfile?padId='+localPadId, 'This will save a file that, when opened, takes you to this pad.') %>
-	      <%= exportLink('doc', 4, 'Microsoft Word', true) %>
-	      <%= exportLink('pdf', 5, 'PDF', true) %>
-	      <%= exportLink('odt', 6, 'OpenDocument', true) %>
 	    </div>
 	  </div><!-- /impexp-export -->
 	  <div id="impexp-divider"><!-- --></div>

--- a/etherpad/src/themes/nano/default/templates/pad/pad_body2.ejs
+++ b/etherpad/src/themes/nano/default/templates/pad/pad_body2.ejs
@@ -156,9 +156,6 @@ limitations under the License. */ %>
 	      <%= exportLink('html', 1, 'HTML', false) %>
 	      <%= exportLink('txt', 2, 'Plain text', false) %>
 	      <%= exportLink('link', 3, 'Bookmark file', false, '/ep/pad/linkfile?padId='+localPadId, 'This will save a file that, when opened, takes you to this pad.') %>
-	      <%= exportLink('doc', 4, 'Microsoft Word', true) %>
-	      <%= exportLink('pdf', 5, 'PDF', true) %>
-	      <%= exportLink('odt', 6, 'OpenDocument', true) %>
 	    </div>
 	  </div><!-- /impexp-export -->
 	  <div id="impexp-divider"><!-- --></div>

--- a/etherpad/src/themes/nano/default/templates/pad/pad_content.ejs
+++ b/etherpad/src/themes/nano/default/templates/pad/pad_content.ejs
@@ -193,17 +193,17 @@ limitations under the License. */ %><%
       <table>
 				<tr>
 					<td class="firsttd"><%= exportOption('html', 'HTML', false) %></td>
-      		<td class="secondtd"><%= exportOption('doc', 'Microsoft Word', true) %></td>
+      		<td class="secondtd">&nbsp;</td>
 				</tr>
 				<tr>
 					<td class="firsttd"><%= exportOption('txt', 'Plain text', false) %></td>
-      		<td class="secondtd"><%= exportOption('pdf', 'PDF', true) %></td>
+      		<td class="secondtd">&nbsp;</td>
 				</tr>
 				<tr>
 					<td class="firsttd"><%= exportOption('link', 'Bookmark file', false,
 																							 '/ep/pad/linkfile?padId='+padId,
 						'This will save a file that, when opened, takes you to this pad.') %></td>
-					<td class="secondtd"><%= exportOption('odt', 'OpenDocument', true) %></td>
+					<td class="secondtd">&nbsp;</td>
 				</tr>
 			</table>
 			<div id="exportmessage"></div>

--- a/etherpad/src/themes/nano/templates/pad/pad_body2.ejs
+++ b/etherpad/src/themes/nano/templates/pad/pad_body2.ejs
@@ -170,9 +170,6 @@ limitations under the License. */ %>
 	      <%= exportLink('html', 1, 'HTML', false) %>
 	      <%= exportLink('txt', 2, 'Plain text', false) %>
 	      <%= exportLink('link', 3, 'Bookmark file', false, '/ep/pad/linkfile?padId='+localPadId, 'This will save a file that, when opened, takes you to this pad.') %>
-	      <%= exportLink('doc', 4, 'Microsoft Word', true) %>
-	      <%= exportLink('pdf', 5, 'PDF', true) %>
-	      <%= exportLink('odt', 6, 'OpenDocument', true) %>
 	    </div>
 	  </div><!-- /impexp-export -->
 	  <div id="impexp-divider"><!-- --></div>


### PR DESCRIPTION
Further research exposes that we don't have the environment necessary to support PDF/DOC/ODT export at this time. As a courtesy to users, rather than showing damaged options that don't work, this patch hides them so. This is not an ideal solution, but it's what we have available at this time. Future etherpad solutions should improve things noticeably.